### PR TITLE
Add global sound preference menu

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,8 @@ import EditAvatar from "./pages/EditAvatar";
 import WelcomeAnimationLogin from "./pages/WelcomeAnimationLogin";
 import MinimalQr from "./components/minimalQr";
 import XafariContext from "./components/XafariContext";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import SoundMenu from "./components/SoundMenu";
 
 function App() {
   // carga user desde localStorage o lo define
@@ -31,6 +32,13 @@ function App() {
     },
   });
   const [token, setToken] = useState(localStorage.getItem(null) || null);
+  const [soundSetting, setSoundSetting] = useState(() => {
+    if (typeof window === "undefined") {
+      return "full";
+    }
+
+    return localStorage.getItem("soundSetting") || "full";
+  });
 
   useEffect(() => {
     try {
@@ -52,6 +60,14 @@ function App() {
     localStorage.setItem("token", JSON.stringify(token));
   }, [token]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    localStorage.setItem("soundSetting", soundSetting);
+  }, [soundSetting]);
+
   return (
     <XafariContext.Provider
       value={{
@@ -59,8 +75,11 @@ function App() {
         setUser,
         token,
         setToken,
+        soundSetting,
+        setSoundSetting,
       }}
     >
+      <SoundMenu />
       <Routes>
         <Route path="/" element={<Welcome />} />
         <Route path="/welcome" element={<Welcome />} />

--- a/frontend/src/components/SoundMenu.jsx
+++ b/frontend/src/components/SoundMenu.jsx
@@ -1,0 +1,109 @@
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useTranslation } from "react-i18next";
+import XafariContext from "./XafariContext";
+
+const SOUND_OPTIONS = [
+  { value: "full", labelKey: "soundFull", icon: "🔊" },
+  { value: "medium", labelKey: "soundMedium", icon: "🔉" },
+  { value: "vibrate", labelKey: "soundVibrate", icon: "📳" },
+  { value: "off", labelKey: "soundOff", icon: "🔇" },
+];
+
+export default function SoundMenu() {
+  const { soundSetting, setSoundSetting } = useContext(XafariContext);
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  const activeOption = useMemo(() => {
+    return (
+      SOUND_OPTIONS.find((option) => option.value === soundSetting) ||
+      SOUND_OPTIONS[0]
+    );
+  }, [soundSetting]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3"
+    >
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="sound-menu"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            transition={{ duration: 0.2 }}
+            className="w-52 rounded-2xl bg-white/90 p-3 text-sm shadow-lg backdrop-blur"
+          >
+            <p className="mb-2 font-semibold text-gray-700">
+              {t("soundMenu")}
+            </p>
+            <div className="flex flex-col gap-2">
+              {SOUND_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    setSoundSetting(option.value);
+                    setOpen(false);
+                    if (
+                      option.value === "vibrate" &&
+                      typeof navigator !== "undefined" &&
+                      navigator.vibrate
+                    ) {
+                      navigator.vibrate(100);
+                    }
+                  }}
+                  className={`flex items-center justify-between rounded-xl border px-3 py-2 text-left transition ${
+                    activeOption.value === option.value
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-600"
+                      : "border-transparent bg-white/80 text-gray-700 hover:bg-gray-100"
+                  }`}
+                >
+                  <span className="text-lg">{option.icon}</span>
+                  <span className="text-xs font-medium">
+                    {t(option.labelKey)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-sm font-medium text-gray-800 shadow-lg backdrop-blur transition hover:bg-white"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label={t("soundMenu")}
+      >
+        <span className="text-lg">{activeOption.icon}</span>
+        <span>
+          {t("soundMenu")}: {t(activeOption.labelKey)}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/XafariContext.jsx
+++ b/frontend/src/components/XafariContext.jsx
@@ -20,6 +20,8 @@ const XafariContext = createContext({
   token: null,
   setToken: () => {},
   xecretos: {},
+  soundSetting: "full",
+  setSoundSetting: () => {},
 });
 
 export default XafariContext;

--- a/frontend/src/locales/en/global.json
+++ b/frontend/src/locales/en/global.json
@@ -9,5 +9,10 @@
   "scan": "Find and scan",
   "discover_guardian": "Discover the guardian",
   "next": "Next",
-  "profile":"Profile"
+  "profile": "Profile",
+  "soundMenu": "Sound",
+  "soundFull": "Full sound",
+  "soundMedium": "Medium sound",
+  "soundVibrate": "Vibrate only",
+  "soundOff": "Mute"
 }

--- a/frontend/src/locales/es/global.json
+++ b/frontend/src/locales/es/global.json
@@ -9,5 +9,10 @@
   "scan": "Encuentra y escanea",
   "discover_guardian": "Descubre al guardián",
   "next": "Siguiente",
-  "profile":"Perfil"
+  "profile": "Perfil",
+  "soundMenu": "Sonido",
+  "soundFull": "Con sonido",
+  "soundMedium": "Sonido medio",
+  "soundVibrate": "Solo vibrar",
+  "soundOff": "Sin sonido"
 }


### PR DESCRIPTION
## Summary
- add a persistent sound preference state to the global context
- introduce a floating sound menu with options for full, medium, vibrate-only, and mute
- localize the new sound controls in English and Spanish

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e546b1a6208330b036c3e3f200c8a5