### PR TITLE
Refine floating sound menu spacing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,8 @@ import EditAvatar from "./pages/EditAvatar";
 import WelcomeAnimationLogin from "./pages/WelcomeAnimationLogin";
 import MinimalQr from "./components/minimalQr";
 import XafariContext from "./components/XafariContext";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import SoundMenu from "./components/SoundMenu";
 
 function App() {
   // carga user desde localStorage o lo define
@@ -31,6 +32,13 @@ function App() {
     },
   });
   const [token, setToken] = useState(localStorage.getItem(null) || null);
+  const [soundSetting, setSoundSetting] = useState(() => {
+    if (typeof window === "undefined") {
+      return "full";
+    }
+
+    return localStorage.getItem("soundSetting") || "full";
+  });
 
   useEffect(() => {
     try {
@@ -52,6 +60,14 @@ function App() {
     localStorage.setItem("token", JSON.stringify(token));
   }, [token]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    localStorage.setItem("soundSetting", soundSetting);
+  }, [soundSetting]);
+
   return (
     <XafariContext.Provider
       value={{
@@ -59,8 +75,11 @@ function App() {
         setUser,
         token,
         setToken,
+        soundSetting,
+        setSoundSetting,
       }}
     >
+      <SoundMenu />
       <Routes>
         <Route path="/" element={<Welcome />} />
         <Route path="/welcome" element={<Welcome />} />

--- a/frontend/src/components/SoundMenu.jsx
+++ b/frontend/src/components/SoundMenu.jsx
@@ -1,0 +1,53 @@
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import XafariContext from "./XafariContext";
+
+const SOUND_OPTIONS = [
+  { value: "full", labelKey: "soundFull", icon: "🔊" },
+  { value: "medium", labelKey: "soundMedium", icon: "🔉" },
+  { value: "vibrate", labelKey: "soundVibrate", icon: "📳" },
+  { value: "off", labelKey: "soundOff", icon: "🔇" },
+];
+
+export default function SoundMenu() {
+  const { soundSetting, setSoundSetting } = useContext(XafariContext);
+  const { t } = useTranslation();
+
+  return (
+    <div className="pointer-events-none fixed top-4 right-4 z-40 flex flex-col items-end">
+      <div className="mt-[3.5rem] rounded-2xl bg-white/90 p-2 shadow-lg backdrop-blur pointer-events-auto">
+        <div className="flex items-center gap-2">
+          {SOUND_OPTIONS.map((option) => {
+            const isActive = soundSetting === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setSoundSetting(option.value);
+                  if (
+                    option.value === "vibrate" &&
+                    typeof navigator !== "undefined" &&
+                    navigator.vibrate
+                  ) {
+                    navigator.vibrate(100);
+                  }
+                }}
+                className={`flex h-10 w-10 items-center justify-center rounded-full text-xl transition ${
+                  isActive
+                    ? "bg-emerald-100 text-emerald-600 shadow-inner"
+                    : "bg-white/0 text-gray-700 hover:bg-gray-100"
+                }`}
+                aria-label={`${t("soundMenu")}: ${t(option.labelKey)}`}
+                title={t(option.labelKey)}
+              >
+                <span aria-hidden="true">{option.icon}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/XafariContext.jsx
+++ b/frontend/src/components/XafariContext.jsx
@@ -20,6 +20,8 @@ const XafariContext = createContext({
   token: null,
   setToken: () => {},
   xecretos: {},
+  soundSetting: "full",
+  setSoundSetting: () => {},
 });
 
 export default XafariContext;

--- a/frontend/src/locales/en/global.json
+++ b/frontend/src/locales/en/global.json
@@ -9,5 +9,10 @@
   "scan": "Find and scan",
   "discover_guardian": "Discover the guardian",
   "next": "Next",
-  "profile":"Profile"
+  "profile": "Profile",
+  "soundMenu": "Sound",
+  "soundFull": "Full sound",
+  "soundMedium": "Medium sound",
+  "soundVibrate": "Vibrate only",
+  "soundOff": "Mute"
 }

--- a/frontend/src/locales/es/global.json
+++ b/frontend/src/locales/es/global.json
@@ -9,5 +9,10 @@
   "scan": "Encuentra y escanea",
   "discover_guardian": "Descubre al guardián",
   "next": "Siguiente",
-  "profile":"Perfil"
+  "profile": "Perfil",
+  "soundMenu": "Sonido",
+  "soundFull": "Con sonido",
+  "soundMedium": "Sonido medio",
+  "soundVibrate": "Solo vibrar",
+  "soundOff": "Sin sonido"
 }


### PR DESCRIPTION
## Summary
- shift the floating sound controls to sit directly beneath the existing language or family toggle in the top-right corner
- compress the selector into a horizontal row of icon buttons while preserving accessibility support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e546b1a6208330b036c3e3f200c8a5