### PR TITLE
Polish sound menu icons

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,8 @@ import EditAvatar from "./pages/EditAvatar";
 import WelcomeAnimationLogin from "./pages/WelcomeAnimationLogin";
 import MinimalQr from "./components/minimalQr";
 import XafariContext from "./components/XafariContext";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import SoundMenu from "./components/SoundMenu";
 
 function App() {
   // carga user desde localStorage o lo define
@@ -31,6 +32,13 @@ function App() {
     },
   });
   const [token, setToken] = useState(localStorage.getItem(null) || null);
+  const [soundSetting, setSoundSetting] = useState(() => {
+    if (typeof window === "undefined") {
+      return "full";
+    }
+
+    return localStorage.getItem("soundSetting") || "full";
+  });
 
   useEffect(() => {
     try {
@@ -52,6 +60,14 @@ function App() {
     localStorage.setItem("token", JSON.stringify(token));
   }, [token]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    localStorage.setItem("soundSetting", soundSetting);
+  }, [soundSetting]);
+
   return (
     <XafariContext.Provider
       value={{
@@ -59,8 +75,11 @@ function App() {
         setUser,
         token,
         setToken,
+        soundSetting,
+        setSoundSetting,
       }}
     >
+      <SoundMenu />
       <Routes>
         <Route path="/" element={<Welcome />} />
         <Route path="/welcome" element={<Welcome />} />

--- a/frontend/src/components/SoundMenu.jsx
+++ b/frontend/src/components/SoundMenu.jsx
@@ -1,0 +1,120 @@
+import { useContext } from "react";
+import { useTranslation } from "react-i18next";
+import XafariContext from "./XafariContext";
+
+const SOUND_ICONS = {
+  full: (
+    <svg
+      className="h-6 w-6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.5 14.25v-4.5a.75.75 0 0 1 .75-.75H8.4a.75.75 0 0 0 .53-.22l3.08-3.08c.48-.48 1.29-.14 1.29.53v14.14c0 .67-.81 1.01-1.29.53l-3.08-3.08a.75.75 0 0 0-.53-.22H5.25a.75.75 0 0 1-.75-.75Z" />
+      <path d="M17.25 8.25c1.5 1.5 1.5 6 0 7.5" />
+      <path d="M19.5 6c2.25 2.25 2.25 9.75 0 12" />
+    </svg>
+  ),
+  medium: (
+    <svg
+      className="h-6 w-6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.5 14.25v-4.5a.75.75 0 0 1 .75-.75H8.4a.75.75 0 0 0 .53-.22l3.08-3.08c.48-.48 1.29-.14 1.29.53v14.14c0 .67-.81 1.01-1.29.53l-3.08-3.08a.75.75 0 0 0-.53-.22H5.25a.75.75 0 0 1-.75-.75Z" />
+      <path d="M17.25 8.25c1.5 1.5 1.5 6 0 7.5" />
+    </svg>
+  ),
+  vibrate: (
+    <svg
+      className="h-6 w-6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="7.5" y="3" width="9" height="18" rx="2.25" />
+      <path d="M5.25 8.25 3.75 9.75 5.25 11.25 3.75 12.75 5.25 14.25 3.75 15.75" />
+      <path d="M18.75 8.25 20.25 9.75 18.75 11.25 20.25 12.75 18.75 14.25 20.25 15.75" />
+    </svg>
+  ),
+  off: (
+    <svg
+      className="h-6 w-6"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.5 14.25v-4.5a.75.75 0 0 1 .75-.75H8.4a.75.75 0 0 0 .53-.22l3.08-3.08c.48-.48 1.29-.14 1.29.53v14.14c0 .67-.81 1.01-1.29.53l-3.08-3.08a.75.75 0 0 0-.53-.22H5.25a.75.75 0 0 1-.75-.75Z" />
+      <path d="m16.5 7.5 3 3-3 3" />
+      <path d="M19.5 7.5 16.5 10.5" />
+    </svg>
+  ),
+};
+
+const SOUND_OPTIONS = [
+  { value: "full", labelKey: "soundFull" },
+  { value: "medium", labelKey: "soundMedium" },
+  { value: "vibrate", labelKey: "soundVibrate" },
+  { value: "off", labelKey: "soundOff" },
+];
+
+export default function SoundMenu() {
+  const { soundSetting, setSoundSetting } = useContext(XafariContext);
+  const { t } = useTranslation();
+
+  return (
+    <div className="pointer-events-none fixed top-4 right-4 z-40 flex flex-col items-end">
+      <div className="mt-[3.5rem] rounded-2xl bg-white/90 p-2 shadow-lg backdrop-blur pointer-events-auto">
+        <div role="group" aria-label={t("soundMenu")} className="flex items-center gap-2">
+          {SOUND_OPTIONS.map((option) => {
+            const isActive = soundSetting === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => {
+                  setSoundSetting(option.value);
+                  if (
+                    option.value === "vibrate" &&
+                    typeof navigator !== "undefined" &&
+                    navigator.vibrate
+                  ) {
+                    navigator.vibrate(100);
+                  }
+                }}
+                className={`flex h-10 w-10 items-center justify-center rounded-full text-xl transition focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white ${
+                  isActive
+                    ? "bg-emerald-100 text-emerald-600 shadow-inner"
+                    : "bg-white/0 text-gray-700 hover:bg-gray-100"
+                }`}
+                aria-label={`${t("soundMenu")}: ${t(option.labelKey)}`}
+                title={t(option.labelKey)}
+                aria-pressed={isActive}
+              >
+                <span aria-hidden="true">{SOUND_ICONS[option.value]}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/XafariContext.jsx
+++ b/frontend/src/components/XafariContext.jsx
@@ -20,6 +20,8 @@ const XafariContext = createContext({
   token: null,
   setToken: () => {},
   xecretos: {},
+  soundSetting: "full",
+  setSoundSetting: () => {},
 });
 
 export default XafariContext;

--- a/frontend/src/locales/en/global.json
+++ b/frontend/src/locales/en/global.json
@@ -9,5 +9,10 @@
   "scan": "Find and scan",
   "discover_guardian": "Discover the guardian",
   "next": "Next",
-  "profile":"Profile"
+  "profile": "Profile",
+  "soundMenu": "Sound",
+  "soundFull": "Full sound",
+  "soundMedium": "Medium sound",
+  "soundVibrate": "Vibrate only",
+  "soundOff": "Mute"
 }

--- a/frontend/src/locales/es/global.json
+++ b/frontend/src/locales/es/global.json
@@ -9,5 +9,10 @@
   "scan": "Encuentra y escanea",
   "discover_guardian": "Descubre al guardián",
   "next": "Siguiente",
-  "profile":"Perfil"
+  "profile": "Perfil",
+  "soundMenu": "Sonido",
+  "soundFull": "Con sonido",
+  "soundMedium": "Sonido medio",
+  "soundVibrate": "Solo vibrar",
+  "soundOff": "Sin sonido"
 }


### PR DESCRIPTION
## Summary
- replace the sound setting emojis with custom inline SVG icons so the compact menu stays stylistically consistent with the UI
- add aria group semantics and pressed state feedback for the icon-only buttons while keeping their fixed placement beneath the language/family toggle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e546b1a6208330b036c3e3f200c8a5